### PR TITLE
Assets: fix resolveUri from mounting point.

### DIFF
--- a/src/Engine/Assets/AssetRegistry.cpp
+++ b/src/Engine/Assets/AssetRegistry.cpp
@@ -104,17 +104,15 @@ String AssetRegistry::resolvePathFromUri( const IO::Uri &location ) {
     String absPath( pathToCheck );
     String::size_type pos = pathToCheck.find( "/" );
     String mountPoint = pathToCheck.substr( 0, pos );
+    String::size_type offset = pos + mountPoint.size() + 1;
     if ( hasPath( mountPoint ) ) {
         absPath = getPath( mountPoint );
         if ( absPath[ absPath.size()-1 ]!='/' ) {
             absPath += '/';
+            offset++;
         }
-        
-        String::size_type endPos = pathToCheck.rfind( "/" );
-        absPath += pathToCheck.substr( pos+1, pathToCheck.size()-( pos + endPos-2 ));
-        if ( absPath[ absPath.size()-1 ]!='/' ) {
-            absPath += '/';
-        }
+        String rest = pathToCheck.substr( pos+1, pathToCheck.size() - pos-1 );
+        absPath += rest;
     }
     
     return absPath;

--- a/src/Engine/Assets/AssimpWrapper.cpp
+++ b/src/Engine/Assets/AssimpWrapper.cpp
@@ -58,7 +58,7 @@ bool AssimpWrapper::importAsset( const IO::Uri &file, ui32 flags ) {
     String root = AssetRegistry::getPath( "media" );
     String path = AssetRegistry::resolvePathFromUri( file );
 
-    String filename = root + path + file.getResource();
+    String filename = root + path;
     Importer myImporter;
     const aiScene *scene = myImporter.ReadFile( filename, flags );
     if ( nullptr == scene ) {

--- a/test/UnitTests/src/Assets/AssetRegistryTest.cpp
+++ b/test/UnitTests/src/Assets/AssetRegistryTest.cpp
@@ -32,8 +32,8 @@ using namespace ::OSRE::Assets;
 class AssetRegistryTest : public ::testing::Test {
 protected:
     virtual void SetUp() {
-#ifdef OSRE_WINDOWS
         AssetRegistry *reg( AssetRegistry::create() );
+#ifdef OSRE_WINDOWS
         Assets::AssetRegistry::registerAssetPath( "assets", "../../media" );
 #else
         Assets::AssetRegistry::registerAssetPath( "assets", "../media" );
@@ -62,7 +62,7 @@ TEST_F( AssetRegistryTest, resolve_uri_from_mount_Test ) {
     static const String ModelPath = "file://assets/Models/Obj/spider.obj";
     IO::Uri fileUri( ModelPath );
     String loc = AssetRegistry::resolvePathFromUri( fileUri );
-    static const String expRes = "../../media/models/Obj/Spider.obj";
+    static const String expRes = "../../media/Models/Obj/spider.obj";
     EXPECT_EQ( expRes, loc );
 }
 

--- a/test/UnitTests/src/Assets/AssetRegistryTest.cpp
+++ b/test/UnitTests/src/Assets/AssetRegistryTest.cpp
@@ -62,7 +62,11 @@ TEST_F( AssetRegistryTest, resolve_uri_from_mount_Test ) {
     static const String ModelPath = "file://assets/Models/Obj/spider.obj";
     IO::Uri fileUri( ModelPath );
     String loc = AssetRegistry::resolvePathFromUri( fileUri );
+#ifdef OSRE_WINDOWS
     static const String expRes = "../../media/Models/Obj/spider.obj";
+#else
+    static const String expRes = "../media/Models/Obj/spider.obj";
+#endif
     EXPECT_EQ( expRes, loc );
 }
 


### PR DESCRIPTION
AssetRegistry::resolvePathFromUri was buggy, will be fixed by this pull requests.