### PR TITLE
rename editor

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,9 +4,6 @@
 [submodule "contrib/assimp"]
 	path = contrib/assimp
 	url = https://github.com/assimp/assimp.git
-[submodule "imgui"]
-	path = contrib/imgui
-	url = https://github.com/ocornut/imgui.git
 [submodule "contrib/vcpkg"]
 	path = contrib/vcpkg
 	url = https://github.com/microsoft/vcpkg.git

--- a/src/Editor_imgui/CMakeLists.txt
+++ b/src/Editor_imgui/CMakeLists.txt
@@ -79,7 +79,7 @@ SOURCE_GROUP(Scripting\\              FILES ${scripting_src} )
 
 SOURCE_GROUP(Main\\                   FILES ${main_src})
 
-ADD_EXECUTABLE( osre_ed_imgui
+ADD_EXECUTABLE( osre_ed
     ${actions_src}
     ${gui_src}
     ${inspector_module_src}
@@ -92,7 +92,7 @@ ADD_EXECUTABLE( osre_ed_imgui
 )
 
 IF(WIN32)
-  target_link_libraries( osre_ed_imgui osre ${Python3_LIBRARIES} Ws2_32 SDL2::SDL2 )
+  target_link_libraries( osre_ed osre ${Python3_LIBRARIES} Ws2_32 SDL2::SDL2 )
 ELSE()
-  target_link_libraries( osre_ed_imgui osre ${Python3_LIBRARIES} SDL2::SDL2 )
+  target_link_libraries( osre_ed osre ${Python3_LIBRARIES} SDL2::SDL2 )
 ENDIF(WIN32)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Removed the unused "imgui" submodule from project configuration, simplifying dependency management.
	- Renamed the executable target from `osre_ed_imgui` to `osre_ed`, improving clarity while maintaining existing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->